### PR TITLE
Add explicit nullable param types (PHP 8.4 deprecation)

### DIFF
--- a/src/Model/Tables/MelisPagePublishedTable.php
+++ b/src/Model/Tables/MelisPagePublishedTable.php
@@ -47,7 +47,7 @@ class MelisPagePublishedTable extends MelisGenericTable
      * @param int|null $siteId
      * @return \Laminas\Db\ResultSet\ResultSetInterface
      */
-    public function getPagesByType(string $pageType = null, int $siteId = null)
+    public function getPagesByType(?string $pageType = null, ?int $siteId = null)
     {
         $select = $this->tableGateway->getSql()->select();
 

--- a/src/Model/Tables/MelisPageSavedTable.php
+++ b/src/Model/Tables/MelisPageSavedTable.php
@@ -46,7 +46,7 @@ class MelisPageSavedTable extends MelisGenericTable
      * @param int|null $siteId
      * @return \Laminas\Db\ResultSet\ResultSetInterface
      */
-    public function getPagesByType(string $pageType = null, int $siteId = null)
+    public function getPagesByType(?string $pageType = null, ?int $siteId = null)
     {
         $select = $this->tableGateway->getSql()->select();
 

--- a/src/Service/MelisGdprService.php
+++ b/src/Service/MelisGdprService.php
@@ -27,10 +27,10 @@ class MelisGdprService extends MelisGeneralService
      * @return mixed
      */
     public function saveBanner(
-        int $bannerId = null,
+        ?int $bannerId = null,
         string $content = '',
-        int $siteId = null,
-        int $langId = null
+        ?int $siteId = null,
+        ?int $langId = null
     )
     {
         // Event parameters prepare
@@ -73,7 +73,7 @@ class MelisGdprService extends MelisGeneralService
         return $arrayParameters['results'];
     }
 
-    public function deleteBannerById(int $bannerId = null)
+    public function deleteBannerById(?int $bannerId = null)
     {
         // Event parameters prepare
         $arrayParameters = $this->makeArrayFromParameters(__METHOD__, func_get_args());
@@ -106,7 +106,7 @@ class MelisGdprService extends MelisGeneralService
      * @param int|null $langId
      * @return mixed
      */
-    public function getGdprBannerText(int $siteId = null, int $langId = null)
+    public function getGdprBannerText(?int $siteId = null, ?int $langId = null)
     {
         // Event parameters prepare
         $arrayParameters = $this->makeArrayFromParameters(__METHOD__, func_get_args());


### PR DESCRIPTION
## What

PHP 8.4 deprecates **implicitly nullable parameters** (`Type $x = null`). This makes
them explicit (`?Type $x = null`) in `src/` — e.g. `MelisPagePublishedTable::getPagesByType()`
and `MelisGdprService::saveBanner()`, which emit the deprecation during normal CMS use.

## Safety

**Behaviour-preserving** (PHP already treats `Type $x = null` as nullable). Generated
with PHP-CS-Fixer (`nullable_type_declaration_for_default_null_value`), `php -l` clean.
3 files, `?`-only changes.

## Context

Reference PR for the PHP 8.4 support effort (melisplatform/melis-core#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)